### PR TITLE
fix  upnp_callback

### DIFF
--- a/main.c
+++ b/main.c
@@ -45,7 +45,7 @@ void signal_handler(int signum)
 	return;
 }
 
-int upnp_callback(Upnp_EventType eventtype, void *event, void *cookie)
+int upnp_callback(Upnp_EventType eventtype, const void *event, void *cookie)
 {
 	return UPNP_E_SUCCESS;
 }


### PR DESCRIPTION
Fixes GCC warning:

main.c:357:31: warning: passing argument 5 of 'UpnpRegisterRootDevice2' from incompatible pointer type [-Wincompatible-pointer-types]
  357 |                               upnp_callback, &upnp_device, &upnp_device);
      |                               ^~~~~~~~~~~~~
      |                               |
      |                               int (*)(Upnp_EventType,  void *, void *) {aka int (*)(enum Upnp_EventType_e,  void *, void *)}